### PR TITLE
refactor(render): validate construction plan in applyRenderFilters

### DIFF
--- a/lib/Flynt/Render.php
+++ b/lib/Flynt/Render.php
@@ -4,8 +4,6 @@ namespace Flynt;
 
 class Render {
   public static function fromConstructionPlan($constructionPlan) {
-    self::validateConstructionPlan($constructionPlan);
-
     $areaHtml = self::extractAreaHtml($constructionPlan);
 
     return self::applyRenderFilters($constructionPlan, $areaHtml);
@@ -14,6 +12,9 @@ class Render {
   protected static function validateConstructionPlan($constructionPlan) {
     if (empty($constructionPlan)) {
       trigger_error('Empty Construction Plan!', E_USER_WARNING);
+      return false;
+    } else {
+      return true;
     }
   }
 
@@ -30,6 +31,10 @@ class Render {
   }
 
   protected static function applyRenderFilters($constructionPlan, $areaHtml) {
+    if (self::validateConstructionPlan($constructionPlan) === false) {
+      return '';
+    }
+
     $componentData = $constructionPlan['data'];
     $componentName = $constructionPlan['name'];
 


### PR DESCRIPTION
I believe we can move the `validateConstructionPlan` call in the `applyRenderFilters`. If the construction plan is empty, `extractAreaHtml` won't do anything. 

By doing so, I can also return an empty string, instead of creating PHP errors : when it's empty, all the lines in `applyRenderFilters` will create an error.