### PR TITLE
Build Construction Plan Validation

### DIFF
--- a/lib/Flynt/BuildConstructionPlan.php
+++ b/lib/Flynt/BuildConstructionPlan.php
@@ -117,15 +117,13 @@ class BuildConstructionPlan {
       $areaNames = array_keys($config['areas']);
       $config['areas'] = array_reduce($areaNames, function ($output, $areaName) use ($config, $parentData) {
         $components = $config['areas'][$areaName];
-        $output[$areaName] = self::mapAreaComponents($components, $config, $areaName, $parentData);
+        $output[$areaName] = array_filter(self::mapAreaComponents($components, $config, $areaName, $parentData));
         return $output;
       }, []);
     }
 
     // remove empty 'areas' key from config
-    // this can happen if:
-    // 1. there were no areas defined to begin with
-    // 2. there were areas defined, but no components in them
+    // this can happen if there were no areas defined to begin with
     if (empty($config['areas'])) {
       unset($config['areas']);
     }

--- a/tests/test-buildConstructionPlan.php
+++ b/tests/test-buildConstructionPlan.php
@@ -631,6 +631,34 @@ class BuildConstructionPlanTest extends TestCase {
     ]);
   }
 
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   */
+  function testInvalidComponentsInAreasAreRemoved() {
+    $parentComponentName = 'ComponentWithArea';
+    $childComponentName = 'DoesNotExist';
+
+    $component = TestHelper::getCustomComponent($parentComponentName, ['name', 'areas']);
+
+    $component['areas'] = [
+      'area51' => [
+        TestHelper::getCustomComponent($childComponentName, ['name'])
+      ]
+    ];
+
+    $this->mockComponentManager();
+
+    $cp = @BuildConstructionPlan::fromConfig($component, $this->componentList);
+    $this->assertEquals($cp, [
+      'name' => $parentComponentName,
+      'data' => [],
+      'areas' => [
+        'area51' => []
+      ]
+    ]);
+  }
+
   // Helpers
   function mockComponentManager() {
     $componentManagerMock = Mockery::mock('ComponentManager');


### PR DESCRIPTION
- some refactoring of tests
- add tests for customData and parentData (must be arrays now, prevents array_merge warnings)
- removing empty components in areas (this lead to a bug causing a number of PHP errors in the Render class previously)