### PR TITLE
docs(wordpress): use correct version and URI

### DIFF
--- a/flynt-core.php
+++ b/flynt-core.php
@@ -4,7 +4,7 @@
  * Plugin URI:      https://github.com/flyntwp/flynt-core
  * Description:     Adds the Core Functionality for the Flynt Framework.
  * Author:          bleech GmbH
- * Author URI:      http://bleech.de
+ * Author URI:      https://bleech.de
  * Text Domain:     flynt-core
  * Domain Path:     /languages
  * Version:         1.0.0

--- a/flynt-core.php
+++ b/flynt-core.php
@@ -1,13 +1,13 @@
 <?php
 /**
  * Plugin Name:     Flynt Core
- * Plugin URI:      https://github.com/bleech/wp-starter-plugin
+ * Plugin URI:      https://github.com/flyntwp/flynt-core
  * Description:     Adds the Core Functionality for the Flynt Framework.
  * Author:          bleech GmbH
  * Author URI:      http://bleech.de
  * Text Domain:     flynt-core
  * Domain Path:     /languages
- * Version:         0.1.0
+ * Version:         1.0.0
  *
  * @package         Flynt_Core_Plugin
  */


### PR DESCRIPTION
Not sure if this demands a version bump. If so, adjust the version before merging.

Or is there possibly a way to automate this process as well?