### PR TITLE
Before & After Actions

### DIFF
--- a/lib/Flynt/BuildConstructionPlan.php
+++ b/lib/Flynt/BuildConstructionPlan.php
@@ -6,7 +6,13 @@ class BuildConstructionPlan
 {
     public static function fromConfig($config)
     {
-        return self::fromConfigRecursive($config);
+        do_action('Flynt/beforeBuildConstructionPlan', $config);
+
+        $constructionPlan = self::fromConfigRecursive($config);
+
+        do_action('Flynt/afterBuildConstructionPlan', $constructionPlan);
+
+        return $constructionPlan;
     }
 
     protected static function fromConfigRecursive($config, $parentData = [])

--- a/lib/Flynt/Render.php
+++ b/lib/Flynt/Render.php
@@ -6,6 +6,17 @@ class Render
 {
     public static function fromConstructionPlan($constructionPlan)
     {
+        do_action('Flynt/beforeRenderConstructionPlan', $constructionPlan);
+
+        $html = self::recursivelyRenderFromConstructionPlan($constructionPlan);
+
+        do_action('Flynt/afterRenderConstructionPlan', $constructionPlan);
+
+        return $html;
+    }
+
+    protected static function recursivelyRenderFromConstructionPlan($constructionPlan)
+    {
         if (false === self::validateConstructionPlan($constructionPlan)) {
             return '';
         }
@@ -98,7 +109,7 @@ class Render
             trigger_error("Area \"{$areaName}\" is not an array!", E_USER_WARNING);
             return '';
         }
-        return implode('', array_map('self::fromConstructionPlan', $components));
+        return implode('', array_map('self::recursivelyRenderFromConstructionPlan', $components));
     }
 
     protected static function applyRenderFilters($constructionPlan, $areaHtml)

--- a/tests/test-buildConstructionPlan.php
+++ b/tests/test-buildConstructionPlan.php
@@ -15,6 +15,7 @@ require_once dirname(__DIR__) . '/lib/Flynt/BuildConstructionPlan.php';
 
 use StdClass;
 use Mockery;
+use Brain\Monkey\WP\Actions;
 use Brain\Monkey\WP\Filters;
 use Flynt\Tests\TestCase;
 use Flynt\BuildConstructionPlan;
@@ -684,6 +685,25 @@ class BuildConstructionPlanTest extends TestCase
         'area51' => []
         ]
         ]);
+    }
+
+    public function testDoesBeforeAndAfterActions()
+    {
+        $config = [
+            'name' => 'test'
+        ];
+
+        $expectedConstructionPlan = [];
+
+        Actions::expectFired('Flynt/beforeBuildConstructionPlan')
+        ->once()
+        ->with($config);
+
+        Actions::expectFired('Flynt/afterBuildConstructionPlan')
+        ->once()
+        ->with($expectedConstructionPlan);
+
+        $cp = @BuildConstructionPlan::fromConfig($config);
     }
 
   // Helpers

--- a/tests/test-render.php
+++ b/tests/test-render.php
@@ -14,6 +14,7 @@ namespace Flynt\Tests;
 require_once dirname(__DIR__) . '/lib/Flynt/Render.php';
 
 use Mockery;
+use Brain\Monkey\WP\Actions;
 use Brain\Monkey\WP\Filters;
 use Flynt\Tests\TestCase;
 use Flynt\Render;
@@ -155,5 +156,22 @@ class RenderTest extends TestCase
 
         $html = Render::fromConstructionPlan($cp);
         $this->assertEquals($html, $shouldBeHtml);
+    }
+
+    public function testDoesBeforeAndAfterActions()
+    {
+        $constructionPlan = [
+            'name' => 'test'
+        ];
+
+        Actions::expectFired('Flynt/beforeRenderConstructionPlan')
+        ->once()
+        ->with($constructionPlan);
+
+        Actions::expectFired('Flynt/afterRenderConstructionPlan')
+        ->once()
+        ->with($constructionPlan);
+
+        @Render::fromConstructionPlan($constructionPlan);
     }
 }


### PR DESCRIPTION
Added before and after actions to BuildConstructionPlan and Render. We can use this for logging and performance monitoring (and maybe more) in the future.